### PR TITLE
Reuse Mojular function to get Sass paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 
 var importPaths = [];
-importPaths.push(require('mojular-govuk-elements').getPaths('sass'));
+importPaths.push(require('mojular-govuk-elements').sassPaths);
 
 gulp.task('sass', function() {
   var result = gulp.src('path/to/your/local/styles/**/*.scss')
@@ -34,9 +34,8 @@ gulp.task('sass', function() {
 
 Each Mojular module containing Sass files exposes its paths in `package.json` file.
 These then can be passed to Sass compiler via `includePaths` and allows to import them
-directly by file names as if they were local. Each module which includes Sass files has
-`getPaths()` method which gets the list of paths to Sass files. Additional modules can
-be `push`ed as required.
+directly by file names as if they were local. Each module should have a property `sassPaths`
+that collects Sass paths defined in its `package.json`.
 
 **Rails**
 

--- a/index.js
+++ b/index.js
@@ -1,26 +1,5 @@
-var packageMeta = require('./package.json');
-var util = require('util');
-
-function prefixPaths(paths) {
-  return paths.map(function(path) {
-    return util.format('node_modules/%s/%s', packageMeta.name, path);
-  });
-}
+var mojular = require('mojular');
 
 module.exports = {
-  getPaths: function(key) {
-    var paths = packageMeta.paths;
-    if(paths) {
-      Object.keys(paths).forEach(function(k) {
-        paths[k] = prefixPaths(paths[k]);
-      });
-    } else {
-      paths = [];
-    }
-    if(!paths[key]) {
-      throw new Error('`' + key + '` can’t be found in paths');
-    }
-
-    return paths[key];
-  }
+  sassPaths: mojular.getSassPaths(require('./package.json'))
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bourbon": "^4.2.5",
     "include-media": "^1.4.1",
+    "mojular": "mojular/mojular",
     "susy": "^2.2.6"
   },
   "paths": {


### PR DESCRIPTION
Use Mojular as dependency to reduce code repetition to get Sass paths.

Depends on [mojular#3](https://github.com/mojular/mojular/pull/3).
