### PR TITLE
Adjust space around text inputs and below form labels

### DIFF
--- a/sass/govuk/elements/forms/_form-control.scss
+++ b/sass/govuk/elements/forms/_form-control.scss
@@ -3,7 +3,7 @@
 .form-control {
   box-sizing: border-box;
   border: 2px solid $grey-1;
-  padding: em(8) em(7) em(5);
+  padding: 4px;
   border-radius: 0;
   width: 50%;
   min-width: 5em;

--- a/sass/govuk/elements/forms/_form-labels.scss
+++ b/sass/govuk/elements/forms/_form-labels.scss
@@ -2,7 +2,6 @@
 
 .form-label {
   display: block;
-  margin-bottom: em(5);
 }
 
 .block-label {


### PR DESCRIPTION
to align with http://govuk-elements.herokuapp.com/form-elements/

Now:
![screen shot 2016-02-10 at 15 47 20](https://cloud.githubusercontent.com/assets/69542/12952585/dd64d27a-d00e-11e5-9d8e-32c6eecda184.png)

govuk-elements:
![screen shot 2016-02-10 at 15 47 30](https://cloud.githubusercontent.com/assets/69542/12952619/f6ab0024-d00e-11e5-961c-c534d8c76230.png)
